### PR TITLE
Change replace text to literals

### DIFF
--- a/lib/wsTrustClient.js
+++ b/lib/wsTrustClient.js
@@ -2,8 +2,9 @@
  * WsTrust Client
  * @author Leandro Boffi (@leandroboffi)
  */
-
-var templates  = { rst : '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><s:Header><a:Action s:mustUnderstand="1">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue</a:Action><a:To s:mustUnderstand="1">[To]</a:To><o:Security s:mustUnderstand="1" xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><o:UsernameToken u:Id="uuid-6a13a244-dac6-42c1-84c5-cbb345b0c4c4-1"><o:Username>[Username]</o:Username><o:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">[Password]</o:Password></o:UsernameToken></o:Security></s:Header><s:Body><trust:RequestSecurityToken xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512"><wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"><a:EndpointReference><a:Address>[ApplyTo]</a:Address></a:EndpointReference></wsp:AppliesTo><trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</trust:KeyType><trust:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</trust:RequestType><trust:TokenType>urn:oasis:names:tc:SAML:2.0:assertion</trust:TokenType></trust:RequestSecurityToken></s:Body></s:Envelope>' };
+const template = ({ endpoint, username, password, scope }) => {
+		return `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><s:Header><a:Action s:mustUnderstand="1">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue</a:Action><a:To s:mustUnderstand="1">${endpoint}</a:To><o:Security s:mustUnderstand="1" xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><o:UsernameToken u:Id="uuid-6a13a244-dac6-42c1-84c5-cbb345b0c4c4-1"><o:Username>${username}</o:Username><o:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">${password}</o:Password></o:UsernameToken></o:Security></s:Header><s:Body><trust:RequestSecurityToken xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512"><wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"><a:EndpointReference><a:Address>${scope}</a:Address></a:EndpointReference></wsp:AppliesTo><trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</trust:KeyType><trust:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</trust:RequestType><trust:TokenType>urn:oasis:names:tc:SAML:2.0:assertion</trust:TokenType></trust:RequestSecurityToken></s:Body></s:Envelope>`;
+	};
 
 var https = require('https');
 var url = require('url');
@@ -12,14 +13,15 @@ exports.version = '0.0.1';
 
 exports.requestSecurityToken = function(options, callback, errorCallback) {
 
-	var message = templates.rst;
+	// Defined variable
+	var endpoint = options.endpoint;
+	var username = options.username;
+	var password = options.password;
+	var scope = options.scope;
+
+	var message = render(template, { endpoint, username, password, scope});
 	var uri = url.parse(options.endpoint);
-	
-	message = message.replace("[To]", options.endpoint);
-	message = message.replace("[Username]", options.username);	
-	message = message.replace("[Password]", options.password);
-	message = message.replace("[ApplyTo]", options.scope);
-	
+
 	var post_options = {
 		host: uri.host,
 		port: '443',
@@ -31,27 +33,27 @@ exports.requestSecurityToken = function(options, callback, errorCallback) {
 		}
 	};
 
-	var req = https.request(post_options, function(res) {
+	var req = https.request(post_options, function(resp) {
 
-		res.setEncoding('utf8');
+		resp.setEncoding('utf8');
 
-		res.on('data', function(data) {
+		resp.on('data', function(data) {
 
 			var rstr = {
 				token: parseRstr(data),
-				response: res,
+				response: resp,
+
 			};
 
 			callback(rstr);
-
 		});
 	});
 
 	req.write(message);
 	req.end();
+
 	req.on('error', function (e) { errorCallback(e); });
 };
-
 
 // Parses the RequestSecurityTokenResponse
 function parseRstr(rstr){
@@ -59,4 +61,9 @@ function parseRstr(rstr){
 	var endOfAssertion = rstr.indexOf('</Assertion>') + '</Assertion>'.length;
 	var token = rstr.substring(startOfAssertion, endOfAssertion);
 	return token;
+}
+
+// Render string templates
+function render(template, data) {
+	return template(data);
 }


### PR DESCRIPTION
Fix a problem when parameter is special character 
Ex. "P@$$w0rd" 
javascript replace function convert to -> "P@$w0rd" missing one of "$"
